### PR TITLE
Update info about YDB: it's now open source

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ This file may be good for experienced developers who:
     <!-- Technology --><td>Distributed DataBase</td>
     <!-- Yandex internal --><td><a href="https://cloud.yandex.ru/services/ydb">Yandex Database (YDB)</a></td>
     <!-- Aanalogs --><td>
-      <a href="https://cloud.yandex.ru/services/ydb">Yandex Database (YDB)</a> (Commercial by Yandex)
+      <a href="https://ydb.tech/">Yandex Database (YDB)</a> (Open source by Yandex)
     </td>
   </tr>
 </table>


### PR DESCRIPTION
YDB is open source since June 2022 (https://medium.com/yandex/ydb-is-now-available-as-open-source-project-f776b16517ce).